### PR TITLE
FIX: spec of get_providers_by_namespace

### DIFF
--- a/src/providers.erl
+++ b/src/providers.erl
@@ -232,7 +232,7 @@ get_provider_by_module(ProviderModule, [_ | Rest]) ->
 get_provider_by_module(_ProviderModule, _) ->
     not_found.
 
--spec get_providers_by_namespace(atom(), [t()]) -> t() | not_found.
+-spec get_providers_by_namespace(atom(), [t()]) -> [t()].
 get_providers_by_namespace(Namespace, [Provider = #provider{namespace = Namespace} | Rest]) ->
     [Provider | get_providers_by_namespace(Namespace, Rest)];
 get_providers_by_namespace(Namespace, [_ | Rest]) ->


### PR DESCRIPTION
The spec of get_providers_by_namespace is mistake.
I fix this.
