### PR TITLE
Add missing erlware_commons dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [{platform_define, "R14", no_callback_support}
            ,debug_info]}.
-{deps, [{getopt, "1.0.1"}]}.
+{deps, [{getopt, "1.0.1"}, {erlware_commons,  "1.4.0"}]}.
 
 


### PR DESCRIPTION
Hello,

While using `providers` I notice a missing dependency. The module `src/providers.erl` uses only one function from erlware_commons,  `ec_cnv:to_list/1`.  This is the shortest path not necessary the best one.

Thanks